### PR TITLE
Set address reuse flag on reader socket, fixes #10

### DIFF
--- a/src/main/java/com/github/besherman/lifx/impl/network/LFXNetworkLoopConnection.java
+++ b/src/main/java/com/github/besherman/lifx/impl/network/LFXNetworkLoopConnection.java
@@ -188,6 +188,7 @@ public class LFXNetworkLoopConnection {
         public Reader(DatagramChannel channel, LFXMessageRouter router) throws IOException {            
             this.router = router;
             channel.configureBlocking(false);
+            channel.socket().setReuseAddress(true);
             channel.socket().bind(new InetSocketAddress(PORT));
 
             selector = Selector.open();


### PR DESCRIPTION
Need to set this flag so that LIFX running in background doesn't cause a BindException on LFXClient open.