### PR TITLE
Adding an option to specify broadcast address

### DIFF
--- a/src/main/java/com/github/besherman/lifx/LFXClient.java
+++ b/src/main/java/com/github/besherman/lifx/LFXClient.java
@@ -42,6 +42,14 @@ public class LFXClient {
         loop = LFXNetworkLoop.getLoop();
         loop.addHandler(lightHandler);
     }
+
+    /**
+     * Creates a new client.
+     */
+    public LFXClient(String broadcastAddress) {
+				this();
+				loop.setBroadcastAddress(broadcastAddress);
+    }
     
     /**
      * Returns the collection of lights.

--- a/src/main/java/com/github/besherman/lifx/impl/network/LFXMessageRouter.java
+++ b/src/main/java/com/github/besherman/lifx/impl/network/LFXMessageRouter.java
@@ -51,7 +51,7 @@ import java.util.logging.Logger;
  */
 public class LFXMessageRouter {    
     private final LFXRoutingTable routingTable = new LFXRoutingTable();    
-    private final LFXNetworkSettings networkSettings = new LFXNetworkSettings();    
+    private final LFXNetworkSettings networkSettings;
     private final LFXLightHandlerModel handlers;
     private final BlockingQueue<LFXSocketMessage> outgoingQueue;
     
@@ -63,7 +63,8 @@ public class LFXMessageRouter {
     private LFXTimerQueue timerQueue;
     
 
-    public LFXMessageRouter(LFXLightHandlerModel handlers, BlockingQueue<LFXSocketMessage> outgoingQueue) {
+    public LFXMessageRouter(String broadcastAddress, LFXLightHandlerModel handlers, BlockingQueue<LFXSocketMessage> outgoingQueue) {
+        networkSettings = new LFXNetworkSettings(broadcastAddress);
         this.handlers = handlers;
         this.outgoingQueue = outgoingQueue;
         this.responseTracker.setOutgoingQueue(outgoingQueue);

--- a/src/main/java/com/github/besherman/lifx/impl/network/LFXNetworkLoop.java
+++ b/src/main/java/com/github/besherman/lifx/impl/network/LFXNetworkLoop.java
@@ -42,6 +42,7 @@ public class LFXNetworkLoop {
     
     private LFXNetworkLoopConnection connection;
     private final Object conLock = new Object();
+    private String broadcastAddress = null;
     
     
     private LFXNetworkLoop() {        
@@ -65,7 +66,7 @@ public class LFXNetworkLoop {
     public void open() throws IOException {
         synchronized(conLock) {
             if(connection == null) {
-                LFXNetworkLoopConnection newConnection = new LFXNetworkLoopConnection(handlers);
+                LFXNetworkLoopConnection newConnection = new LFXNetworkLoopConnection(broadcastAddress, handlers);
                 newConnection.open();
                 connection = newConnection;
             }
@@ -80,6 +81,10 @@ public class LFXNetworkLoop {
             }
         }
     }    
+
+    public void setBroadcastAddress(String broadcastAddress) {
+        this.broadcastAddress = broadcastAddress;
+    }
     
     public void addHandler(LFXLightHandler handler) {
         handlers.addLightHandler(handler);

--- a/src/main/java/com/github/besherman/lifx/impl/network/LFXNetworkLoopConnection.java
+++ b/src/main/java/com/github/besherman/lifx/impl/network/LFXNetworkLoopConnection.java
@@ -68,12 +68,12 @@ public class LFXNetworkLoopConnection {
     private Writer writer;
     private Thread writingThread;        
     
-    public LFXNetworkLoopConnection(LFXLightHandlerModel handlers) {        
+    public LFXNetworkLoopConnection(String broadcastAddress, LFXLightHandlerModel handlers) {
         this.messageSendRateLimitInterval = LFXConstants.getNetworkLoopSendRateLimitInterval();        
         int outgoingQueueSize = LFXConstants.getOutgoingQueueSize();
         
         this.outgoingQueue = new PriorityBlockingQueue<>(outgoingQueueSize);
-        this.router = new LFXMessageRouter(handlers, outgoingQueue);
+        this.router = new LFXMessageRouter(broadcastAddress, handlers, outgoingQueue);
     }
     
     

--- a/src/main/java/com/github/besherman/lifx/impl/network/LFXNetworkSettings.java
+++ b/src/main/java/com/github/besherman/lifx/impl/network/LFXNetworkSettings.java
@@ -30,6 +30,7 @@ import java.net.InetSocketAddress;
 import java.net.InterfaceAddress;
 import java.net.NetworkInterface;
 import java.net.SocketException;
+import java.net.UnknownHostException;
 import java.util.Enumeration;
 
 /**
@@ -41,18 +42,24 @@ public class LFXNetworkSettings {
     
     private final int broadcastPort = 56700;
     private final int peerToPeerPort = 56750;
+    private final String broadcastAddressString;
     
-    
-    public LFXNetworkSettings() {
-        
+    public LFXNetworkSettings(String broadcastAddressString) {
+        this.broadcastAddressString = broadcastAddressString;
     }
 
     /**
      * Returns the broadcast address that sockets should use.
      */
-    public synchronized InetSocketAddress getBroadcast() throws SocketException {
+    public synchronized InetSocketAddress getBroadcast() throws SocketException, UnknownHostException {
         if(broadcastAddress == null) {
-            broadcastAddress = new InetSocketAddress(getFirstActiveBroadcast(), broadcastPort);
+            if (broadcastAddressString == null) {
+                broadcastAddress = new InetSocketAddress(getFirstActiveBroadcast(), broadcastPort);
+            }
+            else {
+                InetAddress addr = InetAddress.getByName(broadcastAddressString);
+                broadcastAddress = new InetSocketAddress(addr, broadcastPort);
+            }
         }
         return broadcastAddress;
     }


### PR DESCRIPTION
Don't know if you're accepting pull requests,  feel free to discard this one if not.

I could not connect to any lights because the library was defaulting to broadcasting on an interface created by vmware (player), not the physical network card. I think there's no heuristic which could work to find the right interface for everyone, so I added an optional way to specify the broadcast address when instantiating the LFXClient. 
